### PR TITLE
cd_timers

### DIFF
--- a/src/scenes/functionalities/cd_timer.tscn
+++ b/src/scenes/functionalities/cd_timer.tscn
@@ -1,11 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://b6mtdlqlyaox8"]
 
-[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_1k5ox"]
-properties/0/path = NodePath(".:wait_time")
-properties/0/spawn = true
-properties/0/replication_mode = 1
+[ext_resource type="Script" path="res://scripts/functionalities/cd_timer.gd" id="1_f4abc"]
 
 [node name="cd_timer" type="Timer"]
-
-[node name="synchronizer" type="MultiplayerSynchronizer" parent="."]
-replication_config = SubResource("SceneReplicationConfig_1k5ox")
+script = ExtResource("1_f4abc")

--- a/src/scenes/functionalities/cd_timer.tscn
+++ b/src/scenes/functionalities/cd_timer.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3 uid="uid://b6mtdlqlyaox8"]
+
+[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_1k5ox"]
+properties/0/path = NodePath(".:wait_time")
+properties/0/spawn = true
+properties/0/replication_mode = 1
+
+[node name="cd_timer" type="Timer"]
+
+[node name="synchronizer" type="MultiplayerSynchronizer" parent="."]
+replication_config = SubResource("SceneReplicationConfig_1k5ox")

--- a/src/scenes/units/player.tscn
+++ b/src/scenes/units/player.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://dempeiar8tjic"]
+[gd_scene load_steps=8 format=3 uid="uid://dempeiar8tjic"]
 
 [ext_resource type="Script" path="res://scripts/units/player.gd" id="1_8gonl"]
+[ext_resource type="Script" path="res://scripts/functionalities/cd_timer_container.gd" id="3_ise05"]
 [ext_resource type="Script" path="res://scripts/functionalities/player_input.gd" id="4_lp8kc"]
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_16yd3"]
@@ -52,8 +53,5 @@ replication_config = SubResource("SceneReplicationConfig_rfg56")
 replication_config = SubResource("SceneReplicationConfig_kjxoy")
 script = ExtResource("4_lp8kc")
 
-[node name="cd_timers" type="Node" parent="."]
-
-[node name="cd_timer_spawner" type="MultiplayerSpawner" parent="cd_timers"]
-_spawnable_scenes = PackedStringArray("res://scenes/functionalities/cd_timer.tscn")
-spawn_path = NodePath("..")
+[node name="cd_timer_container" type="Node" parent="."]
+script = ExtResource("3_ise05")

--- a/src/scenes/units/player.tscn
+++ b/src/scenes/units/player.tscn
@@ -55,4 +55,5 @@ script = ExtResource("4_lp8kc")
 [node name="cd_timers" type="Node" parent="."]
 
 [node name="cd_timer_spawner" type="MultiplayerSpawner" parent="cd_timers"]
+_spawnable_scenes = PackedStringArray("res://scenes/functionalities/cd_timer.tscn")
 spawn_path = NodePath("..")

--- a/src/scripts/functionalities/cd_timer.gd
+++ b/src/scripts/functionalities/cd_timer.gd
@@ -1,0 +1,14 @@
+extends Timer
+
+
+# full duration can differ from the actual wait_time, as it is only used to normalize
+# the cd swipe position. this is useful for spells that have their cd affected by other events.
+var cd_full_duration: float
+var spell_node: Node
+
+
+func trigger_cd(full_duration: float, duration: float) -> void:
+	# set full duration
+	cd_full_duration = full_duration
+	wait_time = duration
+	start()

--- a/src/scripts/functionalities/cd_timer_container.gd
+++ b/src/scripts/functionalities/cd_timer_container.gd
@@ -2,7 +2,6 @@ extends Node
 
 
 func relay_cd_timer(spell_id: String, full_duration: float, duration: float):
-	print(get_parent().name)
 	rpc_id(get_parent().name.to_int(),"start_cd_timer",spell_id,full_duration,duration)
 
 

--- a/src/scripts/functionalities/cd_timer_container.gd
+++ b/src/scripts/functionalities/cd_timer_container.gd
@@ -1,0 +1,11 @@
+extends Node
+
+
+func relay_cd_timer(spell_id: String, full_duration: float, duration: float):
+	print(get_parent().name)
+	rpc_id(get_parent().name.to_int(),"start_cd_timer",spell_id,full_duration,duration)
+
+
+@rpc("authority","call_local")
+func start_cd_timer(spell_id: String, full_duration: float, duration: float):
+	get_node("cd_timer_spell_%s"%spell_id).trigger_cd(full_duration,duration)

--- a/src/scripts/functionalities/player_input.gd
+++ b/src/scripts/functionalities/player_input.gd
@@ -49,7 +49,6 @@ func request_enter_spell_container(spell_id: String):
 
 @rpc("authority","call_local")
 func enter_spell_container(spell_id: String):
-	print("spell requested: %s"%spell_id)
 	$"../spell_container".spell_entrypoint(spell_id)
 
 

--- a/src/scripts/functionalities/spell_container.gd
+++ b/src/scripts/functionalities/spell_container.gd
@@ -1,11 +1,13 @@
 extends Node
 
-var gcd_timer = 1.5
+var player = get_parent()
+var gcd_timer: float = 1.5
+var result: int
 signal signal_gcd(duration)
 
 ################################################################################
 # ENTRYPOINT FROM ACTIONBAR
-func spell_entrypoint(spell_id: String):
+func spell_entrypoint(spell_id: String) -> int:
 	# determine whether spell is present in container
 	var node_name = "spell_"+spell_id
 	var spell_node = get_node_or_null(node_name)
@@ -14,7 +16,16 @@ func spell_entrypoint(spell_id: String):
 		return 1  # spell not known
 	# trigger spell
 	print("triggering ",spell_id)
-	spell_node.trigger()
+	result = spell_node.trigger()
+	## player specific section
+	#if not player.is_in_group("player"):
+		#return result
+	#if result == 0:
+		## trigger cd in cd timer of player
+		#player.get_node("cd_timers").start_cd_timer(
+			#spell_id,spell_node.spell_current["cooldown"],spell_node.cd_timer.wait_time
+			#)
+	return result
 
 # apply role swap changes
 
@@ -22,5 +33,5 @@ func spell_entrypoint(spell_id: String):
 
 # send gcd
 func send_gcd() -> void:
-	# emit signal
-	signal_gcd.emit(gcd_timer)
+	# emit signal, true to denote gcd
+	signal_gcd.emit(gcd_timer,true)

--- a/src/scripts/spells/BaseSpellScript.gd
+++ b/src/scripts/spells/BaseSpellScript.gd
@@ -6,8 +6,11 @@ var spell_base: Dictionary
 var spell_current: Dictionary
 var cd_timer = Timer.new()
 var use_mouseover_target = false
+var full_duration: float  # full duration of the cooldown, not necessarily equal to timer wait_time
+var spell_id_string: String
 
 func initialize_base_spell(spell_id: String) -> void:
+	spell_id_string = spell_id
 	# load spell data from data file
 	var json_dict = JSON.parse_string(FileAccess.get_file_as_string("res://data/db_spells.json"))
 	spell_base = json_dict[spell_id]
@@ -69,13 +72,22 @@ func is_not_in_line_of_sight(source: CharacterBody3D, target_position: Vector3) 
 
 ####################################################################################################
 # COOLDOWN
-func trigger_cd(duration: float) -> void:
+func trigger_cd(duration: float, is_gcd: bool = false) -> void:
 	# check if current cooldown exceeds requested cooldown
 	if cd_timer.time_left > duration:
 		return
 	# start timer
 	cd_timer.wait_time = duration
 	cd_timer.start()
+	# start timer in player actionbars
+	if not get_parent().get_parent().is_in_group("player"):
+		return
+	if is_gcd:
+		full_duration = get_parent().gcd_timer
+	else:
+		full_duration = spell_current["cooldown"]
+	get_parent().get_parent().get_node("cd_timer_container").\
+		relay_cd_timer(spell_id_string,full_duration,duration)
 
 
 ####################################################################################################

--- a/src/scripts/spells/spell_10.gd
+++ b/src/scripts/spells/spell_10.gd
@@ -4,7 +4,7 @@ extends BaseSpell
 func _ready():
 	initialize_base_spell("10")
 
-func trigger():
+func trigger() -> int:
 	# get source and target nodes
 	var source = get_parent().get_parent()
 	var target = get_spell_target(source)
@@ -41,3 +41,4 @@ func trigger():
 		get_parent().send_gcd()
 	# send event to combat script
 	Combat.combat_event_entrypoint(spell_current,source,target)
+	return 0

--- a/src/scripts/spells/spell_11.gd
+++ b/src/scripts/spells/spell_11.gd
@@ -29,3 +29,4 @@ func trigger():
 	trigger_cd(spell_current["cooldown"])
 	# send event to combat script
 	Combat.combat_event_aura_entrypoint(spell_current,source,source)
+	return 0

--- a/src/scripts/spells/spell_12.gd
+++ b/src/scripts/spells/spell_12.gd
@@ -13,7 +13,7 @@ func trigger():
 		target = source
 	# check target legality
 	if is_illegal_target(spell_current["targetgroup"], target):
-		return 1
+		target = source
 	# check for cooldown
 	if is_on_cd():
 		return 2

--- a/src/scripts/spells/spell_12.gd
+++ b/src/scripts/spells/spell_12.gd
@@ -40,3 +40,4 @@ func trigger():
 		get_parent().send_gcd()
 	# send event to combat script
 	Combat.combat_event_entrypoint(spell_current,source,target)
+	return 0

--- a/src/scripts/spells/spell_13.gd
+++ b/src/scripts/spells/spell_13.gd
@@ -29,3 +29,4 @@ func trigger():
 	trigger_cd(spell_current["cooldown"])
 	# send event to combat script
 	Combat.combat_event_aura_entrypoint(spell_current,source,source)
+	return 0

--- a/src/scripts/spells/spell_14.gd
+++ b/src/scripts/spells/spell_14.gd
@@ -29,3 +29,4 @@ func trigger():
 	trigger_cd(spell_current["cooldown"])
 	# send event to combat script
 	Combat.combat_event_aura_entrypoint(spell_current,source,source)
+	return 0

--- a/src/scripts/ui/actionbar_slot.gd
+++ b/src/scripts/ui/actionbar_slot.gd
@@ -23,10 +23,8 @@ func set_icon(spell_icon) -> void:
 
 
 func set_hotkey() -> void:
-	print("setting hotkey for %s to %s"%[name,InputMap.action_get_events(name)])
 	shortcut = Shortcut.new()
 	shortcut.events = InputMap.action_get_events(name)
-	print("hotkey for %s is set as %s"%[name,shortcut.events])
 
 
 func _on_pressed() -> void:

--- a/src/scripts/ui/actionbar_slot.gd
+++ b/src/scripts/ui/actionbar_slot.gd
@@ -1,9 +1,12 @@
 extends Button
 
-var slot_spell_id: String
+var slot_spell_id: String = ""
+var spell_cd_timer: Timer
 
 
 func _process(_delta: float) -> void:
+	if slot_spell_id == "":
+		return
 	cooldown_swipe()
 
 
@@ -12,7 +15,8 @@ func init(spell_info: Array) -> void:
 	set_icon(spell_info[1])
 	set_hotkey()
 	pressed.connect(_on_pressed)
-	set_process(true)
+	spell_cd_timer = References.player_reference.get_node("cd_timer_container").\
+		get_node("cd_timer_spell_%s"%slot_spell_id)
 
 
 func set_icon(spell_icon) -> void:
@@ -35,4 +39,6 @@ func _on_pressed() -> void:
 
 
 func cooldown_swipe() -> void:
-	pass
+	if spell_cd_timer.is_stopped():
+		return
+	$cooldown_swipe.value = spell_cd_timer.time_left / spell_cd_timer.cd_full_duration

--- a/src/scripts/ui/actionbars.gd
+++ b/src/scripts/ui/actionbars.gd
@@ -2,7 +2,6 @@ extends Control
 
 var actionbar_slot = preload("res://scenes/ui/actionbar_slot.tscn")
 var actions: Array
-var spell_map: Dictionary
 
 func initialize() -> void:
 	# add actionbar slots to actionbars
@@ -15,21 +14,14 @@ func initialize() -> void:
 	# get all actionbar InputMap actions and set text to primary event
 	actions = get_actionbar_actions()
 	set_text()
-	# initialize all slots with spell id and spell icon
-	# silly workaround, make persistent spell map later
-	spell_map["1_1"] = ["10","fingersoffrost"]
-	spell_map["1_2"] = ["12","mendingwater"]
-	spell_map["1_3"] = ["11","abyssalshell"]
-	spell_map["1_4"] = ["13","deepcurrent"]
-	spell_map["1_5"] = ["14","succumb"]
-	spell_map["2_1"] = ["10","fingersoffrost"]
-	spell_map["2_2"] = ["12","mendingwater"]
-	spell_map["2_3"] = ["11","abyssalshell"]
-	spell_map["2_4"] = ["13","deepcurrent"]
-	spell_map["2_5"] = ["14","succumb"]
-	for key in spell_map.keys():
-		get_node(NodePath("actionbar%s"%key[0])).\
-			get_node(NodePath("actionbar%s"%key)).init(spell_map[key])
+	## initialize all slots with spell id and spell icon
+	#for key in spell_map.keys():
+		#get_node(NodePath("actionbar%s"%key[0])).\
+			#get_node(NodePath("actionbar%s"%key)).init(spell_map[key])
+
+
+func init_slots(spell_map: Dictionary):
+	pass
 
 
 func get_actionbar_actions() -> Array:

--- a/src/scripts/ui/actionbars.gd
+++ b/src/scripts/ui/actionbars.gd
@@ -4,7 +4,7 @@ var actionbar_slot = preload("res://scenes/ui/actionbar_slot.tscn")
 var actions: Array
 
 func initialize() -> void:
-	# add actionbar slots to actionbars
+	# add actionbar slots to actionbars, linked later from player scene in post_ready
 	for i in range(1,3):
 		for j in range(1,13):
 			var slot = actionbar_slot.instantiate()
@@ -14,14 +14,6 @@ func initialize() -> void:
 	# get all actionbar InputMap actions and set text to primary event
 	actions = get_actionbar_actions()
 	set_text()
-	## initialize all slots with spell id and spell icon
-	#for key in spell_map.keys():
-		#get_node(NodePath("actionbar%s"%key[0])).\
-			#get_node(NodePath("actionbar%s"%key)).init(spell_map[key])
-
-
-func init_slots(spell_map: Dictionary):
-	pass
 
 
 func get_actionbar_actions() -> Array:

--- a/src/scripts/ui_handler.gd
+++ b/src/scripts/ui_handler.gd
@@ -30,6 +30,7 @@ var actionbars
 ####################################################################################################
 # INIT
 func init_ui():
+	References.player_ui_main_reference = $/root/main/ui
 	init_unitframes()
 	init_actionbars()
 
@@ -57,7 +58,7 @@ func initialize_playerframe():
 	playerframe = preload("res://scenes/ui/unitframe_player.tscn")
 	playerframe = playerframe.instantiate()
 	set_playerframe_position()
-	$"/root/main/ui".add_child(playerframe)
+	References.player_ui_main_reference.add_child(playerframe)
 
 
 func set_playerframe_position():
@@ -78,7 +79,7 @@ func initialize_targetframe():
 	targetframe = preload("res://scenes/ui/unitframe_target.tscn")
 	targetframe = targetframe.instantiate()
 	set_targetframe_position()
-	$"/root/main/ui".add_child(targetframe)
+	References.player_ui_main_reference.add_child(targetframe)
 
 
 func set_targetframe_position():
@@ -114,4 +115,4 @@ func hide_targetframe():
 func init_actionbars():
 	actionbars = preload("res://scenes/ui/actionbars.tscn").instantiate()
 	actionbars.initialize()
-	$/root/main/ui.add_child(actionbars)
+	References.player_ui_main_reference.add_child(actionbars)

--- a/src/scripts/units/BaseUnitScript.gd
+++ b/src/scripts/units/BaseUnitScript.gd
@@ -30,10 +30,6 @@ func initialize_base_unit(unittype: String, unit_id: String):
 	# auras
 	var aura_container = preload("res://scenes/functionalities/aura_container.tscn").instantiate()
 	add_child(aura_container)
-	# generate cd timers for players for use with actionbars
-	# these are not the actual serverside timers
-	#if unittype == "player":
-		#cd_timers_init()
 
 
 func stat_init(unit_type: String, unit_id: String) -> void:

--- a/src/scripts/units/BaseUnitScript.gd
+++ b/src/scripts/units/BaseUnitScript.gd
@@ -30,6 +30,10 @@ func initialize_base_unit(unittype: String, unit_id: String):
 	# auras
 	var aura_container = preload("res://scenes/functionalities/aura_container.tscn").instantiate()
 	add_child(aura_container)
+	# generate cd timers for players for use with actionbars
+	# these are not the actual serverside timers
+	#if unittype == "player":
+		#cd_timers_init()
 
 
 func stat_init(unit_type: String, unit_id: String) -> void:
@@ -80,3 +84,14 @@ func spell_container_init(spell_list: Array):
 		var spell_scene = load("res://scenes/spells/spell_%s.tscn" % spell)
 		spell_scene = spell_scene.instantiate()
 		$spell_container.add_child(spell_scene)
+
+
+func cd_timers_init():
+	var cd_timer_scene = preload("res://scenes/functionalities/cd_timer.tscn")
+	var timer: Timer
+	for spell in get_node("spell_container").get_children():
+		timer = cd_timer_scene.instantiate()
+		timer.name = "cd_timer_%s"%spell.name
+		timer.one_shot = false
+		get_node("cd_timers").add_child(timer)
+	print(get_node("cd_timers").get_children())

--- a/src/scripts/units/player.gd
+++ b/src/scripts/units/player.gd
@@ -56,10 +56,10 @@ func post_ready(peer_id: int):
 	rpc_id(peer_id,"load_ui_initial")
 	# load spell_map from file
 	rpc_id(peer_id,"load_spell_map")
-	# generate cd timer
-	rpc_id(peer_id,"generate_cd_timers")
 	# initialize actionbar slots
 	rpc_id(peer_id,"initialize_actionbar_slots")
+	# add cd_timers on server
+	add_cd_timers()
 	# add player camera node for authority only
 	rpc_id(peer_id,"add_player_camera")
 #	# activate input _process for authority
@@ -83,15 +83,21 @@ func load_spell_map():
 	spell_map["13"] = ["deepcurrent",["1_4","2_4"]]
 	spell_map["14"] = ["succumb",["1_5","2_5"]]
 @rpc("authority","call_local")
-func generate_cd_timers():
-	pass
-@rpc("authority","call_local")
 func initialize_actionbar_slots():
 	var actionbars = References.player_ui_main_reference.get_node("actionbars")
 	for key in spell_map.keys():
 		for slot in spell_map[key][1]:
 			actionbars.get_node("actionbar%s"%slot[0]).get_node("actionbar%s"%slot).\
 				init([key,spell_map[key][0]])
+func add_cd_timers():
+	# add cd timers here, instead of before being added, to properly enable synchronization
+	var cd_timer_scene = preload("res://scenes/functionalities/cd_timer.tscn")
+	var timer: Timer
+	for spell in get_node("spell_container").get_children():
+		timer = cd_timer_scene.instantiate()
+		timer.name = "cd_timer_%s"%spell.name
+		timer.one_shot = false
+		get_node("cd_timers").add_child(timer)
 @rpc("authority","call_local")
 func add_player_camera():
 	add_child(load("res://scenes/functionalities/player_camera.tscn").instantiate())

--- a/src/scripts/units/player.gd
+++ b/src/scripts/units/player.gd
@@ -49,6 +49,10 @@ func pre_ready(peer_id: int):
 
 func post_ready(peer_id: int):
 	# some things should be done after _ready is finished
+	# load spell_map from file
+	rpc_id(peer_id,"load_spell_map")
+	# generate cd timer
+	rpc_id(peer_id,"generate_cd_timers")
 	# add player camera node for authority only
 	rpc_id(peer_id,"add_player_camera")
 	# add UI elements
@@ -60,6 +64,12 @@ func post_ready(peer_id: int):
 	print("player %s ready" % name)
 
 
+@rpc("authority","call_local")
+func load_spell_map():
+	pass
+@rpc("authority","call_local")
+func generate_cd_timers():
+	pass
 @rpc("authority","call_local")
 func add_player_camera():
 	add_child(load("res://scenes/functionalities/player_camera.tscn").instantiate())

--- a/src/scripts/units/player.gd
+++ b/src/scripts/units/player.gd
@@ -9,6 +9,7 @@ var playermodel_reference = null
 # when speed changes
 var speed: float = 10.0
 const jump_velocity: float = 4.5
+var gravity = ProjectSettings.get_setting("physics/3d/default_gravity")
 
 # targeting vars
 var space_state
@@ -17,11 +18,9 @@ var space_state
 var interactables: Array = []
 var current_interactable = null  # the currently active interactable
 
-# Get the gravity from the project settings to be synced with RigidBody nodes.
-var gravity = ProjectSettings.get_setting("physics/3d/default_gravity")
-
 # spells
 var spell_map: Dictionary
+
 
 ####################################################################################################
 # FRAME
@@ -40,40 +39,58 @@ func _physics_process(delta) -> void:
 
 ####################################################################################################
 # SPAWNING
-func _enter_tree():
+func _enter_tree() -> void:
 	$player_input.set_multiplayer_authority(str(name).to_int())
 
 
-func pre_ready(peer_id: int):
+func pre_ready(peer_id: int) -> void:
 	name = str(peer_id)
 	# initialize stats for all peers
 	initialize_base_unit("player","0")
 
 
-func post_ready(peer_id: int):
+func post_ready(peer_id: int) -> void:
 	# some things should be done after _ready is finished
-	# add UI elements
-	rpc_id(peer_id,"load_ui_initial")
-	# load spell_map from file
-	rpc_id(peer_id,"load_spell_map")
-	# initialize actionbar slots
-	rpc_id(peer_id,"initialize_actionbar_slots")
-	# add cd_timers on server
-	add_cd_timers()
-	# add player camera node for authority only
-	rpc_id(peer_id,"add_player_camera")
-#	# activate input _process for authority
-	rpc_id(peer_id,"call_set_input_process")
-	print("player %s ready" % name)
+	rpc_id(peer_id,"peer_post_ready")
+	#rpc_id(peer_id,"add_cd_timers")
+	#rpc_id(peer_id,"load_ui_initial")
+	## load spell_map from file
+	#rpc_id(peer_id,"load_spell_map")
+	#rpc_id(peer_id,"initialize_actionbar_slots")
+	#rpc_id(peer_id,"add_player_camera")
+	#rpc_id(peer_id,"call_set_input_process")
+	print("player %s ready"%name)
 
 
 @rpc("authority","call_local")
-func load_ui_initial():
-	# set player reference before initializing the unitframes
+func peer_post_ready():
 	References.player_reference = self
+	add_cd_timers()
+	load_ui_initial()
+	load_spell_map()
+	initialize_actionbar_slots()
+	add_player_camera()
+	call_set_input_process()
+
+
+#@rpc("authority","call_local")
+func add_cd_timers() -> void:
+	var cd_timer_scene = preload("res://scenes/functionalities/cd_timer.tscn")
+	var timer: Timer
+	for spell in stats_current["spell_list"]:
+		timer = cd_timer_scene.instantiate()
+		timer.name = "cd_timer_spell_%s"%spell
+		timer.one_shot = true
+		get_node("cd_timer_container").add_child(timer,true)
+
+
+#@rpc("authority","call_local")
+func load_ui_initial() -> void:
 	UIHandler.init_ui()
-@rpc("authority","call_local")
-func load_spell_map():
+
+
+#@rpc("authority","call_local")
+func load_spell_map() -> void:
 	# this is a temporary workaround, and spell_map should be made persistent in a file
 	# in the future, with every class/role combination having a separate map to make sure
 	# that swapping classes and roles is smooth
@@ -82,28 +99,25 @@ func load_spell_map():
 	spell_map["12"] = ["mendingwater",["1_2","2_2"]]
 	spell_map["13"] = ["deepcurrent",["1_4","2_4"]]
 	spell_map["14"] = ["succumb",["1_5","2_5"]]
-@rpc("authority","call_local")
-func initialize_actionbar_slots():
+
+
+#@rpc("authority","call_local")
+func initialize_actionbar_slots() -> void:
 	var actionbars = References.player_ui_main_reference.get_node("actionbars")
 	for key in spell_map.keys():
 		for slot in spell_map[key][1]:
 			actionbars.get_node("actionbar%s"%slot[0]).get_node("actionbar%s"%slot).\
 				init([key,spell_map[key][0]])
-func add_cd_timers():
-	# add cd timers here, instead of before being added, to properly enable synchronization
-	var cd_timer_scene = preload("res://scenes/functionalities/cd_timer.tscn")
-	var timer: Timer
-	for spell in get_node("spell_container").get_children():
-		timer = cd_timer_scene.instantiate()
-		timer.name = "cd_timer_%s"%spell.name
-		timer.one_shot = false
-		get_node("cd_timers").add_child(timer)
-@rpc("authority","call_local")
-func add_player_camera():
-	add_child(load("res://scenes/functionalities/player_camera.tscn").instantiate())
+
+
+#@rpc("authority","call_local")
+func add_player_camera() -> void:
+	add_child(preload("res://scenes/functionalities/player_camera.tscn").instantiate())
 	$camera_rotation/camera_arm/player_camera.current = true
-@rpc("authority","call_local")
-func call_set_input_process():
+
+
+#@rpc("authority","call_local")
+func call_set_input_process() -> void:
 	input.set_process(true)
 	input.set_process_unhandled_input(true)
 
@@ -154,7 +168,7 @@ func is_legal_target(target_dict: Dictionary) -> bool:
 
 
 @rpc("any_peer","call_local")
-func set_target(requested_target: String, parent: String, is_player: bool = false):
+func set_target(requested_target: String, parent: String, is_player: bool = false) -> void:
 	if requested_target == "":
 		selected_target = null
 	elif is_player:
@@ -165,7 +179,7 @@ func set_target(requested_target: String, parent: String, is_player: bool = fals
 
 ####################################################################################################
 # INTERACTABLES
-func get_nearest_interactable():
+func get_nearest_interactable() -> Node:
 	# get the interactable that is nearest to the player unit
 	var nearest_interactable = null
 	# if only one interactable in range, set to that
@@ -193,20 +207,20 @@ func get_nearest_interactable():
 
 
 @rpc("authority","call_local")
-func show_interact_prompt(interactable_name: String):
+func show_interact_prompt(interactable_name: String) -> void:
 	# rpc that makes interact prompt visible locally
 	$/root/main/maps/active_map/interactables.get_node(interactable_name).\
 	get_node("interact_prompt").visible = true
 
 
 @rpc("authority","call_local")
-func hide_interact_prompt(interactable_name: String):
+func hide_interact_prompt(interactable_name: String) -> void:
 	# rpc that makes interact prompt invisible locally
 	$/root/main/maps/active_map/interactables.get_node(interactable_name).\
 	get_node("interact_prompt").visible = false
 
 
-func handle_movement(delta):
+func handle_movement(delta: float) -> void:
 	# jumping
 	if input.jumping and is_on_floor():
 		velocity.y = jump_velocity


### PR DESCRIPTION
Addresses issue 37

Cooldown timers need to be visualized to players, in the form of cooldown swipes on their actionbars. This requires a spell_map dictionary in the player scene, and a cd_timer node as a container for all timers. The timers need to be available to all peers for future functionality, such as displaying the remaining cooldown on defensives or other important cooldowns.